### PR TITLE
Add continuous integration: Travis and appVeyor

### DIFF
--- a/.integration/appveyor-install-window.sh
+++ b/.integration/appveyor-install-window.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+packages=""
+function mingw_packages
+{
+    arch=x86_64
+    if [ "$PLATFORM" == "x86" ];
+    then
+        arch=i686
+    fi
+
+    prefix="mingw-w64-${arch}-"
+    for i in $1
+    do
+        packages="$prefix""$i "$packages
+    done
+}
+
+mingw_packages "zlib cmake toolchain clang"
+
+sh -c "pacman -S --noconfirm git make $packages"

--- a/.integration/appveyor-launch_tests.sh
+++ b/.integration/appveyor-launch_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export PATH="/mingw64/bin:/usr/local/bin:/usr/bin:/bin:/c/WINDOWS/system32:/c/WINDOWS:/c/WINDOWS/System32/Wbem:/c/WINDOWS/System32/WindowsPowerShell/v1.0"
+bf=$(cygpath ${APPVEYOR_BUILD_FOLDER})
+cd "$bf" || (echo "Cannot go to directory $bf"; return 1)
+
+# Compile
+mkdir -p build
+cd build || exit 1
+cmake .. || exit 1
+make -j4 || exit 1
+cd ..
+
+# Unit test
+(cd build && ./Zipper-test) || exit 1

--- a/.integration/travis-deploy.sh
+++ b/.integration/travis-deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "TODO if deploying is needed"

--- a/.integration/travis-install-linux.sh
+++ b/.integration/travis-install-linux.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+apt-get update && apt-get install -y cmake git g++ clang zlib1g-dev valgrind

--- a/.integration/travis-install-osx.sh
+++ b/.integration/travis-install-osx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function brew_install
+{
+#    (brew outdated "$1" || brew install "$1") || (echo "Error installing $1"; return 1)
+    (brew install "$1") || (echo "Error installing $1"; return 1)
+}
+
+brew update
+#brew upgrade
+brew_install valgrind
+brew link --force valgrind

--- a/.integration/travis-launch_tests.sh
+++ b/.integration/travis-launch_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Compile
+mkdir -p build
+cd build || exit 1
+cmake .. || exit 1
+make -j4 || exit 1
+cd ..
+
+# Unit test
+(cd build && valgrind --track-origins=yes ./Zipper-test) || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: required
+dist: trusty
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+services:
+  - docker
+
+os:
+  - linux
+  - osx
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull ubuntu:17.04 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run -e CXX="$CXX" --name travis-ci -v $TRAVIS_BUILD_DIR:/zipper -td ubuntu:16.04 /bin/bash ; fi
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec -ti travis-ci bash -c "cd zipper && ./.integration/travis-install-linux.sh" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$CXX" != "g++" ]]; then ./.integration/travis-install-osx.sh ; fi
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec -ti travis-ci bash -c "cd zipper && ./.integration/travis-launch_tests.sh" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$CXX" != "g++" ]]; then ./.integration/travis-launch_tests.sh ; fi
+
+after_success:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CXX" == "g++" ]]; then docker exec -ti travis-ci bash -c "cd zipper && ./.integration/travis-deploy.sh" ; fi
+
+after_script:
+  - docker stop travis-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+platform:
+  - x64
+
+environment:
+  MSYSTEM: MSYS
+
+before_build:
+  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
+  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh pacman
+  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh git
+  - C:\msys64\usr\bin\bash -lc "$(cygpath ${APPVEYOR_BUILD_FOLDER})/.integration/appveyor-install-window.sh"
+
+build_script:
+  - C:\msys64\usr\bin\bash -lc "$(cygpath ${APPVEYOR_BUILD_FOLDER})/.integration/appveyor-launch_tests.sh"
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
Add scripts for continuous integration:
* Travis: gcc and clang for Linux 17.04 and OS X.
* appVeyor: MinGW: not yet ok (cmake fails locating zlib)
Note: tested for 64-bits architectures.