### PR TITLE
Ticket #45: Fix for encryption with password

### DIFF
--- a/zipper/tools.cpp
+++ b/zipper/tools.cpp
@@ -6,6 +6,7 @@
 #include <CDirEntry.h>
 
 #include <cstdio>
+#include <iostream>
 
 #if defined(WIN32) && !defined(CYGWIN)
 #  include "tps/dirent.h"
@@ -40,7 +41,8 @@ namespace zipper {
 
     } while (size_read > 0);
 
-    input_stream.seekg(0);
+    input_stream.clear();
+    input_stream.seekg(0, std::ios_base::beg);
     result_crc = calculate_crc;
   }
 

--- a/zipper/zipper.cpp
+++ b/zipper/zipper.cpp
@@ -289,7 +289,7 @@ namespace zipper {
 
 	bool Zipper::add(std::istream& source, const std::string& nameInZip, zipFlags flags)
 	{
-		return m_impl->add(source, nameInZip, "", flags);
+		return m_impl->add(source, nameInZip, m_password, flags);
 	}
 
 	bool Zipper::add(const std::string& fileOrFolderPath, zipFlags flags)


### PR DESCRIPTION
Passworded encryption failed because CRC generation did not rewind the file correctly. This is now fixed in tools.cpp so the password can be passed onto the Impl::add(..) method in Zipper::add(...).

After these changes I am able to create a password protected zip on Win10, using VS2017.
Haven't tested on other platforms.