### PR TITLE
Add new flag to save file prefix

### DIFF
--- a/zipper/zipper.cpp
+++ b/zipper/zipper.cpp
@@ -310,7 +310,15 @@ namespace zipper {
 		else
 		{
 			std::ifstream input(fileOrFolderPath.c_str(), std::ios::binary);
-			add(input, fileNameFromPath(fileOrFolderPath), flags);
+			std::string fullFileName;
+
+			if (flags & Zipper::SaveHierarchy)
+				fullFileName = fileOrFolderPath;
+			else
+				fullFileName = fileNameFromPath(fileOrFolderPath);
+
+			add(input, fullFileName, flags);
+
 			input.close();
 		}
 

--- a/zipper/zipper.h
+++ b/zipper/zipper.h
@@ -13,7 +13,7 @@ namespace zipper {
 	public:
 		// Minizip options/params:
 		//              -o                -a             -0            -1             -9             -j
-		enum zipFlags { Overwrite = 0x01, Append = 0x02, Store = 0x04, Faster = 0x08, Better = 0x10, NoPaths = 0x20 };
+		enum zipFlags { Overwrite = 0x01, Append = 0x02, Store = 0x04, Faster = 0x08, Better = 0x10, NoPaths = 0x20, SaveHierarchy = 0x30 };
 
 		Zipper(std::iostream& buffer);
 		Zipper(std::vector<unsigned char>& buffer);

--- a/zipper/zipper.h
+++ b/zipper/zipper.h
@@ -13,7 +13,7 @@ namespace zipper {
 	public:
 		// Minizip options/params:
 		//              -o                -a             -0            -1             -9             -j
-		enum zipFlags { Overwrite = 0x01, Append = 0x02, Store = 0x04, Faster = 0x08, Better = 0x10, NoPaths = 0x20, SaveHierarchy = 0x30 };
+		enum zipFlags { Overwrite = 0x01, Append = 0x02, Store = 0x04, Faster = 0x08, Better = 0x10, NoPaths = 0x20, SaveHierarchy = 0x40 };
 
 		Zipper(std::iostream& buffer);
 		Zipper(std::vector<unsigned char>& buffer);
@@ -24,7 +24,7 @@ namespace zipper {
 
 		bool add(std::istream& source, const std::string& nameInZip = std::string(), zipFlags flags = Better);
 		bool add(const std::string& fileOrFolderPath, zipFlags flags = Better);
-		
+
 		void open();
 		void close();
 


### PR DESCRIPTION
This flag allows you to not lose file prefix (e.g. ./some/dir/before/file.txt) when you use Zipper::add()

This is useful when the user manually prepares a list of files that will be added to the archive and he wants to keep the full file path. For example, a user may want to write something like this:
```
Zipper zip("someArchive.zip");

namespace fs = std::filesystem;
for (auto entry: fs::recursive_directory_iterator(".")) {
	// Archive files only
	if (fs::is_directory(entry))
		continue;
	
	if (   entry != "./someArchive.zip"
	    && entry != "./itMustBeSkipped.txt") 
	{
		auto flags = Zipper::zipFlags::Better | Zipper::zipFlags::SaveHierarchy;
		zip.add(entry, static_cast<Zipper::zipFlags>(flags));
	}
}
zip.close();
```

P.S. I'm not sure it was better to change zipFlags. It might be better adding another overload to the Zipper::add() function or function with another name, but I thought the zipFlags extending was the best choice
