### PR TITLE
Rename methods fixing english and deprecate older methods

### DIFF
--- a/.integration/appveyor-install-window.sh
+++ b/.integration/appveyor-install-window.sh
@@ -16,6 +16,6 @@ function mingw_packages
     done
 }
 
-mingw_packages "zlib cmake toolchain clang"
+mingw_packages "zlib minizip cmake toolchain clang"
 
 sh -c "pacman -S --noconfirm git make $packages"

--- a/.integration/travis-launch_tests.sh
+++ b/.integration/travis-launch_tests.sh
@@ -7,5 +7,5 @@ cmake .. || exit 1
 make -j4 || exit 1
 cd ..
 
-# Unit test
+# Unit test with valgrind to track possible memory leaks
 (cd build && valgrind --track-origins=yes ./Zipper-test) || exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,3 @@
-version: 1.0.{build}
-image:
-  - Visual Studio 2017
-
-shallow_clone: true
-clone_depth: 1
-
 environment:
   matrix:
     - MSYS2_ARCH: x86_64
@@ -12,15 +5,27 @@ environment:
     - MSYS2_ARCH: i686
       MSYSTEM: MINGW32
 
+clone_depth: 1
+branches:
+  only:
+    - master
+
+install:
+  - set PATH=C:\msys64\usr\bin;%PATH%
+  # Download new keyring until appveyor updates its installation
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+  - bash -lc "pacman -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz --noconfirm"
+  - bash -lc "pacman --needed --noconfirm -Syu"
+  # This is needed because without killing all processes -Su will fail
+  - ps: Get-Process | Where-Object {$_.path -like 'C:\msys64*'} | Stop-Process
+  - bash -lc "pacman --needed --noconfirm -Su"
+
 before_build:
-  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --sysupgrade
   - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh pacman
   - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh git
   - C:\msys64\usr\bin\bash -lc "$(cygpath ${APPVEYOR_BUILD_FOLDER})/.integration/appveyor-install-window.sh"
 
 build_script:
   - C:\msys64\usr\bin\bash -lc "$(cygpath ${APPVEYOR_BUILD_FOLDER})/.integration/appveyor-launch_tests.sh"
-
-branches:
-  only:
-    - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,9 @@
-platform:
-  - x64
-
 environment:
-  MSYSTEM: MSYS
+  matrix:
+    - MSYS2_ARCH: x86_64
+      MSYSTEM: MINGW64
+    - MSYS2_ARCH: i686
+      MSYSTEM: MINGW32
 
 before_build:
   - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,9 @@ branches:
 
 install:
   - set PATH=C:\msys64\usr\bin;%PATH%
+  # Fix appveyor not git cloning recursively
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init --recursive
   # Download new keyring until appveyor updates its installation
   - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   - bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,10 @@
+version: 1.0.{build}
+image:
+  - Visual Studio 2017
+
+shallow_clone: true
+clone_depth: 1
+
 environment:
   matrix:
     - MSYS2_ARCH: x86_64
@@ -6,9 +13,9 @@ environment:
       MSYSTEM: MINGW32
 
 before_build:
-  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
-  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh pacman
-  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh git
+  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --sysupgrade
+  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh pacman
+  - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh git
   - C:\msys64\usr\bin\bash -lc "$(cygpath ${APPVEYOR_BUILD_FOLDER})/.integration/appveyor-install-window.sh"
 
 build_script:

--- a/zipper/unzipper.cpp
+++ b/zipper/unzipper.cpp
@@ -125,7 +125,7 @@ namespace zipper {
       if (!entryinfo.valid())
         return false;
 
-      err = extractToFile(fileName, entryinfo);
+      err = extractFromFile(fileName, entryinfo);
       if (UNZ_OK == err)
       {
         err = unzCloseCurrentFile(m_zf);
@@ -149,7 +149,7 @@ namespace zipper {
       if (!entryinfo.valid())
         return false;
 
-      err = extractToStream(stream, entryinfo);
+      err = extractFromStream(stream, entryinfo);
       if (UNZ_OK == err)
       {
         err = unzCloseCurrentFile(m_zf);
@@ -173,7 +173,7 @@ namespace zipper {
       if (!entryinfo.valid())
         return false;
 
-      err = extractToMemory(outvec, entryinfo);
+      err = extractFromMemory(outvec, entryinfo);
       if (UNZ_OK == err)
       {
         err = unzCloseCurrentFile(m_zf);
@@ -228,7 +228,7 @@ namespace zipper {
     }
 
 
-    int extractToFile(const std::string& filename, ZipEntry& info)
+    int extractFromFile(const std::string& filename, ZipEntry& info)
     {
       int err = UNZ_ERRNO;
 
@@ -240,7 +240,7 @@ namespace zipper {
 
       if (output_file.good())
       {
-        if (UNZ_OK == extractToStream(output_file, info))
+        if (UNZ_OK == extractFromStream(output_file, info))
           err = UNZ_OK;
 
         output_file.close();
@@ -257,7 +257,7 @@ namespace zipper {
       return err;
     }
 
-    int extractToStream(std::ostream& stream, ZipEntry& info)
+    int extractFromStream(std::ostream& stream, ZipEntry& info)
     {
       size_t err = unzOpenCurrentFilePassword(m_zf, m_outer.m_password.c_str());
       if (UNZ_OK != err)
@@ -292,7 +292,7 @@ namespace zipper {
       return (int)err;
     }
 
-    int extractToMemory(std::vector<unsigned char>& outvec, ZipEntry& info)
+    int extractFromMemory(std::vector<unsigned char>& outvec, ZipEntry& info)
     {
       size_t err = UNZ_ERRNO;
 
@@ -443,7 +443,7 @@ namespace zipper {
       }
     }
 
-    bool extractEntryToStream(const std::string& name, std::ostream& stream)
+    bool extractEntryFromStream(const std::string& name, std::ostream& stream)
     {
       if (locateEntry(name))
       {
@@ -456,7 +456,7 @@ namespace zipper {
       }
     }
 
-    bool extractEntryToMemory(const std::string& name, std::vector<unsigned char>& vec)
+    bool extractEntryFromMemory(const std::string& name, std::vector<unsigned char>& vec)
     {
       if (locateEntry(name))
       {
@@ -551,14 +551,14 @@ namespace zipper {
     return m_impl->extractEntry(name, destination);
   }
 
-  bool Unzipper::extractEntryToStream(const std::string& name, std::ostream& stream)
+  bool Unzipper::extractEntryFromStream(const std::string& name, std::ostream& stream)
   {
-    return m_impl->extractEntryToStream(name, stream);
+    return m_impl->extractEntryFromStream(name, stream);
   }
 
-  bool Unzipper::extractEntryToMemory(const std::string& name, std::vector<unsigned char>& vec)
+  bool Unzipper::extractEntryFromMemory(const std::string& name, std::vector<unsigned char>& vec)
   {
-    return m_impl->extractEntryToMemory(name, vec);
+    return m_impl->extractEntryFromMemory(name, vec);
   }
 
 

--- a/zipper/unzipper.h
+++ b/zipper/unzipper.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <memory>
 #include <map>
+#include <iostream> // TODO: to be removed when removing extractEntryToStream and extractEntryToMemory
 
 namespace zipper {
   
@@ -27,8 +28,18 @@ namespace zipper {
     bool extract(const std::string& destination, const std::map<std::string, std::string>& alternativeNames);
     bool extract(const std::string& destination=std::string());
     bool extractEntry(const std::string& name, const std::string& destination = std::string());
-    bool extractEntryToStream(const std::string& name, std::ostream& stream);
-    bool extractEntryToMemory(const std::string& name, std::vector<unsigned char>& vec);
+    bool extractEntryFromStream(const std::string& name, std::ostream& stream);
+    bool extractEntryFromMemory(const std::string& name, std::vector<unsigned char>& vec);
+    inline bool extractEntryToStream(const std::string& name, std::ostream& stream)
+    {
+      std::cerr << "*** warning: extractEntryToStream is deprecated. Use extractEntryFromMemory instead!" << std::endl;
+      return extractEntryFromStream(name, stream);
+    }
+    inline bool extractEntryToMemory(const std::string& name, std::vector<unsigned char>& vec)
+    {
+      std::cerr << "*** warning: extractEntryToMemory is deprecated. Use extractEntryFromMemory instead!" << std::endl;
+      return extractEntryFromMemory(name, vec);
+    }
 
     void close();
 


### PR DESCRIPTION
Following https://github.com/sebastiandev/zipper/issues/53#issuecomment-578271614

@sebastiandev @fbergmann it seems to me that your methods extractEntryToStream, extractEntryToMemory shall be named extractEntryFromStream, extractEntryFromMemory ? Because I'm a nut in English I prefered to create a PR to be sure not to commit something stupid.