### PR TITLE
Add target_include_directories to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,7 +338,12 @@ file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION.txt" VERSION)
 option(BUILD_SHARED_VERSION "Build the shared version of the library." ON)
 if (BUILD_SHARED_VERSION)
   add_library (${ZIPPER_LIBRARY} SHARED ${ZIPPER_SOURCES} ${MINIZIP_SOURCES} )
-  
+  target_include_directories(
+    ${ZIPPER_LIBRARY}
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
   if (UNIX)
     SET_TARGET_PROPERTIES(${ZIPPER_LIBRARY} PROPERTIES
                           SOVERSION ${ZIPPER_VERSION_MAJOR}
@@ -353,6 +358,12 @@ endif()
 option(BUILD_STATIC_VERSION "Build the static version of the library." ON)
 if (BUILD_STATIC_VERSION)
   set(STATIC_ZIPPER_LIBRARY static${ZIPPER_LIBRARY})
+  target_include_directories(
+    ${STATIC_ZIPPER_LIBRARY}
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
   add_library (${STATIC_ZIPPER_LIBRARY} STATIC ${ZIPPER_SOURCES} ${MINIZIP_SOURCES})
   set_target_properties(${STATIC_ZIPPER_LIBRARY} PROPERTIES OUTPUT_NAME ${ZIPPER_LIBRARY})
   target_link_libraries(${STATIC_ZIPPER_LIBRARY} ${LIBZ_LIBRARY} ${EXTRA_LIBS})


### PR DESCRIPTION
If you add [targer_include_directories](https://cmake.org/cmake/help/latest/command/target_include_directories.html) for Zipper, it would make it easier to use CMake to include it in other projects. Allowing for `#include <zipper/zipper.h>` no matter the directory of the zipper source files.