### PR TITLE
Add more inclusive windows enviroment

### DIFF
--- a/zipper/CDirEntry.cpp
+++ b/zipper/CDirEntry.cpp
@@ -18,7 +18,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef WIN32
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER)
 #  include <io.h>
 #  include <direct.h>
 typedef struct _stat STAT;


### PR DESCRIPTION
A minor issue where WIN32 is not always set on windows, as per [Microsoft 2019 own API specification](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019) _WIN32 is normally the one set
