### PR TITLE
Add linking for Cmake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 C++ wrapper around minizip compression library
 
 **Zipper**'s goal is to bring the power and simplicity of minizip to a more object oriented/c++ user friendly library.
-It was born out of the necessity of a compression library that would be reliable, simple and flexible. 
+It was born out of the necessity of a compression library that would be reliable, simple and flexible.
 By flexibility I mean supporting all kinds of inputs and outputs, but specifically been able to compress into memory instead of been restricted to file compression only, and using data from memory instead of just files as well.
 
 ### Features:
@@ -149,7 +149,19 @@ zipper.add(input1, "Test1");
 zipper.close();
 ```
 
+##### Zipping strategies
+
+Possible options to `add()` methods (`enum zipFlags`):
+
+- `Overwrite`: Overwrite existing file.zip.
+- `Append`: Append to existing file.zip.
+- `Store`: Store only.
+- `Faster`: Compress faster.
+- `Better`: Compress better.
+- `NoPaths`: exclude path. store only the file name.
+
 ##### Unzipping
+
 - Getting all entries in zip
 ```c++
 Unzipper unzipper("zipfile.zip");

--- a/README.md
+++ b/README.md
@@ -151,14 +151,11 @@ zipper.close();
 
 ##### Zipping strategies
 
-Possible options to `add()` methods (`enum zipFlags`):
+Possible options to `add()` methods:
 
-- `Overwrite`: Overwrite existing file.zip.
-- `Append`: Append to existing file.zip.
-- `Store`: Store only.
-- `Faster`: Compress faster.
-- `Better`: Compress better.
-- `NoPaths`: exclude path. store only the file name.
+- `zipper::Zipper::Faster`: Compress faster.
+- `zipper::Zipper::Better`: Compress better (default).
+- Do not use other enum zipFlags they are not taken into account.
 
 ##### Unzipping
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ C++ wrapper around minizip compression library
 It was born out of the necessity of a compression library that would be reliable, simple and flexible.
 By flexibility I mean supporting all kinds of inputs and outputs, but specifically been able to compress into memory instead of been restricted to file compression only, and using data from memory instead of just files as well.
 
-### Features:
+### Features
+
 - [x] Create zip in memory
 - [x] Allow files, vector and generic streams as input to zip
 - [x] File mappings for replacing strategies (overwrite if exists or use alternative name from mapping)
 - [x] Password protected zip
 - [x] Multi platform
-
 
 ### Getting Started
 
@@ -37,6 +37,7 @@ sudo dnf install gcc-c++  # for fedora
 ```
 
 #### Compiling
+
 The preferred way is to create a folder for the compilation output to avoid polluting the root folder
 
 ```shell
@@ -51,12 +52,14 @@ make
 #### Installing
 
 Following the previous section `Compiling`, still from the `build` folder, type:
+
 ```shell
 sudo make install
 ```
 
 You will see a message like:
-```
+
+```shell
 Install the project...
 -- Install configuration: "Release"
 -- Installing: /usr/local/lib/libZipper.so.1.0.1
@@ -84,13 +87,14 @@ Install the project...
 -- Installing: /usr/local/lib/cmake/zipperTargets-release.cmake
 ```
 
-### Usage:
+### Usage
 
 There are two classes available Zipper and Unzipper. They behave in the same manner regarding constructors and storage parameters. (for a complete example take a look at the [tests](https://github.com/sebastiandev/zipper/blob/develop/test/file_zip_test.cpp ) using the awesome BDD's from Catch library )
 
-##### Zipping
+#### Zipping
 
 - Creating a zip file with 2 files:
+
 ```c++
 using namespace zipper;
 
@@ -105,6 +109,7 @@ zipper.close();
 ```
 
 - Adding a file by name and an entire folder to a zip:
+
 ```c++
 
 Zipper zipper("ziptest.zip");
@@ -112,6 +117,7 @@ zipper.add("somefile.txt");
 zipper.add("myFolder");
 zipper.close();
 ```
+
 - Creating a zip file using the awesome streams from boost that lets us use a vector as a stream:
 
 ```c++
@@ -126,6 +132,7 @@ zipper.close();
 ```
 
 - Creating a zip in memory stream with files:
+
 ```c++
 #include <boost\interprocess\streams\vectorstream.hpp>
 ...
@@ -139,6 +146,7 @@ zipper.close();
 ```
 
 - Creating a zip in a vector with files:
+
 ```c++
 
 std::vector<char> zip_vect;
@@ -149,17 +157,10 @@ zipper.add(input1, "Test1");
 zipper.close();
 ```
 
-##### Zipping strategies
-
-Possible options to `add()` methods:
-
-- `zipper::Zipper::Faster`: Compress faster.
-- `zipper::Zipper::Better`: Compress better (default).
-- Do not use other enum zipFlags they are not taken into account.
-
 ##### Unzipping
 
 - Getting all entries in zip
+
 ```c++
 Unzipper unzipper("zipfile.zip");
 std::vector<ZipEntry> entries = unzipper.entries();
@@ -167,6 +168,7 @@ unzipper.close();
 ```
 
 - Extracting all entries from zip
+
 ```c++
 Unzipper unzipper("zipfile.zip");
 unzipper.extract();
@@ -174,6 +176,7 @@ unzipper.close();
 ```
 
 - Extracting all entries from zip using alternative names for existing files on disk
+
 ```c++
 std::map<std::string, std::string> alternativeNames = { {"Test1", "alternative_name_test1"} };
 Unzipper unzipper("zipfile.zip");
@@ -182,6 +185,7 @@ unzipper.close();
 ```
 
 - Extracting a single entry from zip
+
 ```c++
 Unzipper unzipper("zipfile.zip");
 unzipper.extractEntry("entry name");
@@ -189,6 +193,7 @@ unzipper.close();
 ```
 
 - Extracting a single entry from zip to memory
+
 ```c++
 std::vector<unsigned char> unzipped_entry;
 Unzipper unzipper("zipfile.zip");
@@ -201,17 +206,37 @@ unzipper.close();
 ##### Linking Zipper to your project
 
 In your project add the needed headers in your c++ files:
+
 ```c++
 #include <zipper/unzipper.h>
 #include <zipper/zipper.h>
 ```
 
 There are several ways to link your project against Zipper:
+
 - Straight forward: `g++ -W -Wall -I/usr/local/include main.cpp -o prog -L/usr/local/lib/ -lZipper -lz`. Note: you may have to adapt `/usr/local` to your installation directory (see the previous section `Installing`). You can also adapt and export your environment variable `LD_LIBRARY_PATH` (via you .bashrc for example).
+
 - Pkg-config is a better alternative to the previous command:
-```
+
+```shell
 g++ -W -Wall main.cpp -o prog `pkg-config zipper --cflags --libs`
 ```
-Indeed pkg-config knows for you where to find libraries and, by default, it will choose the shared library. In the case it is not present then the static library will be chosen. You can force choosing the static library with `pkg-config zipper --static --libs`
+
+Indeed pkg-config knows for you where to find libraries and, by default, it will choose the shared library. In the case it is not present then the static library will be chosen. You can force choosing the static library with `pkg-config libZipper --static --libs`
+
 - Makefile: set `LDFLAGS` to `pkg-config zipper --libs` and set `CPPFLAGS` to `pkg-config zipper --cflags`
-- CMake: TODO
+
+- CMake:  Simply place zipper in your project hieracy, and then use `add_subdirectory(zipper)` or whatever you called the zipper folder. Then link it with `Zipper`/`staticZipper`
+
+```cmake
+Project(projZipper)
+
+add_subdirectory(zipper)
+
+add_executable(projZipper main.cpp)
+target_link_libraries(
+    projZipper
+    PUBLIC
+    staticZipper
+)
+```

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ There are several ways to link your project against Zipper:
 - Straight forward: `g++ -W -Wall -I/usr/local/include main.cpp -o prog -L/usr/local/lib/ -lZipper -lz`. Note: you may have to adapt `/usr/local` to your installation directory (see the previous section `Installing`). You can also adapt and export your environment variable `LD_LIBRARY_PATH` (via you .bashrc for example).
 - Pkg-config is a better alternative to the previous command:
 ```
-g++ -W -Wall main.cpp -o prog `pkg-config libZipper --cflags --libs`
+g++ -W -Wall main.cpp -o prog `pkg-config zipper --cflags --libs`
 ```
-Indeed pkg-config knows for you where to find libraries and, by default, it will choose the shared library. In the case it is not present then the static library will be chosen. You can force choosing the static library with `pkg-config libZipper --static --libs`
+Indeed pkg-config knows for you where to find libraries and, by default, it will choose the shared library. In the case it is not present then the static library will be chosen. You can force choosing the static library with `pkg-config zipper --static --libs`
 - Makefile: set `LDFLAGS` to `pkg-config zipper --libs` and set `CPPFLAGS` to `pkg-config zipper --cflags`
 - CMake: TODO


### PR DESCRIPTION
I add an example of how to link zipper to projects using CMake.
I also fix minor issues my markdown interpreter comlained about. Such as whotespace between header and list, and no trailing ":"