### PR TITLE
Support for msys2 / mingw-w64

### DIFF
--- a/zipper/CDirEntry.cpp
+++ b/zipper/CDirEntry.cpp
@@ -223,7 +223,7 @@ bool CDirEntry::createDir(const std::string & dir, const std::string & parent)
         createDir(actualParent);
     }
 
-#if defined(USE_WINDOWS)
+#if defined(USE_WINDOWS) || defined (__MINGW32__)
     return (mkdir(Dir.c_str()) == 0);
 #else
     return (mkdir(Dir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO) == 0);

--- a/zipper/defs.h
+++ b/zipper/defs.h
@@ -10,7 +10,7 @@ extern "C"
 #include <fcntl.h>
 #include <sys/stat.h>
 
-#if (defined(__WIN32__) || defined(WIN32) || defined(_WIN32) || defined(_WIN64) || defined(_MSC_VER)) && !defined(CYGWIN)
+#if (defined(__WIN32__) || defined(WIN32) || defined(_WIN32) || defined(_WIN64) || defined(_MSC_VER)) && !defined(CYGWIN) && !defined(__MINGW32__)
 #  define USE_WINDOWS 1
 #endif
 
@@ -71,7 +71,7 @@ typedef struct stat STAT;
 #  endif
 #endif
 
-#if defined(USE_WINDOWS)
+#if defined(USE_WINDOWS) || defined (__MINGW32__)
 #  define MKDIR(d) _mkdir(d)
 #  define CHDIR(d) _chdir(d)
 #else

--- a/zipper/tools.cpp
+++ b/zipper/tools.cpp
@@ -8,7 +8,7 @@
 #include <cstdio>
 #include <iostream>
 
-#if (USE_WINDOWS)
+#if defined(USE_WINDOWS)
 #  include "tps/dirent.h"
 #  include "tps/dirent.c"
 #else

--- a/zipper/unzipper.cpp
+++ b/zipper/unzipper.cpp
@@ -192,7 +192,7 @@ public:
 
     void changeFileDate(const std::string& filename, uLong dosdate, tm_unz tmu_date)
     {
-#if (USE_WINDOWS)
+#if defined(USE_WINDOWS)
         HANDLE hFile;
         FILETIME ftm, ftLocal, ftCreate, ftLastAcc, ftLastWrite;
 

--- a/zipper/unzipper.cpp
+++ b/zipper/unzipper.cpp
@@ -192,7 +192,7 @@ public:
 
     void changeFileDate(const std::string& filename, uLong dosdate, tm_unz tmu_date)
     {
-#ifdef _WIN32
+#if (USE_WINDOWS)
         HANDLE hFile;
         FILETIME ftm, ftLocal, ftCreate, ftLastAcc, ftLastWrite;
 


### PR DESCRIPTION
This allows the user to compile under msys2 with mingw. All the changes are tested in Windows 10 with mingw-64 10.2.0 and in Arch linuix with gcc 10.2.0. This commit fixes #72 