### PR TITLE
Appveyor fix

### DIFF
--- a/.integration/appveyor-install-window.sh
+++ b/.integration/appveyor-install-window.sh
@@ -16,6 +16,6 @@ function mingw_packages
     done
 }
 
-mingw_packages "zlib cmake toolchain clang"
+mingw_packages "zlib cmake toolchain clang ninja"
 
 sh -c "pacman -S --noconfirm git make $packages"

--- a/.integration/appveyor-launch_tests.sh
+++ b/.integration/appveyor-launch_tests.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-export PATH="/mingw64/bin:/usr/local/bin:/usr/bin:/bin:/c/WINDOWS/system32:/c/WINDOWS:/c/WINDOWS/System32/Wbem:/c/WINDOWS/System32/WindowsPowerShell/v1.0"
-bf=$(cygpath ${APPVEYOR_BUILD_FOLDER})
-cd "$bf" || (echo "Cannot go to directory $bf"; return 1)
+export PATH="/mingw64/bin"
+cd ${APPVEYOR_BUILD_FOLDER}
 
 # Compile
-mkdir -p build
+cmake -B build -GNinja .
 cd build || exit 1
-cmake .. || exit 1
-make -j4 || exit 1
+cmake --build . || exit 1
 cd ..
 
 # Unit test


### PR DESCRIPTION
I tried to fix Appveyor build, whit those changes the build continues and the tests are passed. This is my first interaction with Appveyor so i don't really know how to use this CI system, in my account those lines didn't work:
```
bf=$(cygpath ${APPVEYOR_BUILD_FOLDER})
cd "$bf" || (echo "Cannot go to directory $bf"; return 1)
```
so i changed them for a simple `cd ${APPVEYOR_BUILD_FOLDER}`, if those lines are need I'm more than happy to revert this change back. This commit needs #73 to be merged first or the build will fail with the error reported in #72