### PR TITLE
Add cpp version for MSVC

### DIFF
--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -116,6 +116,8 @@
 #    define CATCH_CPP14_OR_GREATER
 #  endif
 
+# endif
+
 // unless compiled with /Zc:__cplusplus, the __cplusplus value is 199711L with MSVC
 #ifdef _MSVC_LANG
 #  if _MSVC_LANG >= 201103L

--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -116,6 +116,16 @@
 #    define CATCH_CPP14_OR_GREATER
 #  endif
 
+// unless compiled with /Zc:__cplusplus, the __cplusplus value is 199711L with MSVC
+#ifdef _MSVC_LANG
+#  if _MSVC_LANG >= 201103L
+#    define CATCH_CPP11_OR_GREATER
+#  endif
+
+#  if _MSVC_LANG >= 201402L
+#    define CATCH_CPP14_OR_GREATER
+#  endif
+
 #endif
 
 #ifdef __clang__


### PR DESCRIPTION
Unless you compile with `/Zc:__cplusplus` the macro `__cplusplus` is `199711L`
So I introduced a small fix for this, using `_MSVC_LANG` which is visual studios marco
[source](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/)