### PR TITLE
Correction for windows.h and minizip

### DIFF
--- a/zipper/CDirEntry.cpp
+++ b/zipper/CDirEntry.cpp
@@ -411,7 +411,7 @@ std::vector< std::string > CDirEntry::compilePattern(const std::string & pattern
         start = pos;
         pos = pattern.find_first_of("*?", pos);
 
-        end = std::min(pos, pattern.length());
+        end = (std::min)(pos, pattern.length());
 
         if (start != end)
         {
@@ -482,8 +482,8 @@ bool CDirEntry::makePathRelative(std::string & absolutePath, const std::string &
         return false;
 
     absolutePath = normalize(absolutePath);
-
-    size_t i, imax = std::min(absolutePath.length(), RelativeTo.length());
+    
+    size_t i, imax = (std::min)(absolutePath.length(), RelativeTo.length());
 
     for (i = 0; i < imax; i++)
     {


### PR DESCRIPTION
std::min causes both minizip on different versions to use the define. Using the braces this is solved.