### PR TITLE
Fix compile issue on Linux due to unix not always being set

### DIFF
--- a/zipper/unzipper.cpp
+++ b/zipper/unzipper.cpp
@@ -206,7 +206,7 @@ public:
         }
     }
 
-#elif defined unix || defined __APPLE__
+#elif defined(unix) || defined(__APPLE__) || defined(__linux__)
     void changeFileDate(const std::string& filename, uLong /*dosdate*/, tm_unz tmu_date)
     {
         struct utimbuf ut;


### PR DESCRIPTION
I got an issue with `changeFileDate` when compiling into a costum linux, where for some reason the unix was not set.
This is just a very minor improvment to add support for some of there wierd machines