### PR TITLE
Add basic error_code handeling to unzipper

### DIFF
--- a/zipper/unzipper.cpp
+++ b/zipper/unzipper.cpp
@@ -44,7 +44,7 @@ struct unzipper_error_category : std::error_category
         case unzipper_error::ERROR_LOAD_FILE:
             return "Error loading zip file";
         default:
-            return "This error is not handles";
+            return "Unkown Error";
         }
     };
     unzipper_error_category() {};

--- a/zipper/unzipper.cpp
+++ b/zipper/unzipper.cpp
@@ -36,6 +36,7 @@ struct unzipper_error_category : std::error_category
         case unzipper_error::NO_ERROR:
             return "There was no error";
         case unzipper_error::GENERIC_ERROR:
+            return "There was an error";
         case unzipper_error::NO_ENTRY:
             return "Error, couldn't get the current entry info";
         case unzipper_error::ERROR_LOAD_MEMORY:

--- a/zipper/unzipper.h
+++ b/zipper/unzipper.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <memory>
 #include <map>
+#include <system_error>
 
 namespace zipper {
 
@@ -18,7 +19,6 @@ class ZipEntry;
 class Unzipper
 {
 public:
-
     // -------------------------------------------------------------------------
     //! \brief Regular zip decompressor (from zip archive file).
     //!
@@ -27,6 +27,9 @@ public:
     //!   if no password is needed).
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
+    Unzipper(std::error_code& ec, const std::string& zipname,
+             const std::string& password = std::string());
+
     Unzipper(const std::string& zipname,
              const std::string& password = std::string());
 
@@ -38,6 +41,8 @@ public:
     //!   if no password is needed).
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
+    Unzipper(std::error_code& ec, std::istream& buffer,
+             const std::string& password = std::string());
     Unzipper(std::istream& buffer,
              const std::string& password = std::string());
 
@@ -49,6 +54,8 @@ public:
     //!   if no password is needed).
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
+    Unzipper(std::error_code& ec, std::vector<unsigned char>& buffer,
+             const std::string& password = std::string());
     Unzipper(std::vector<unsigned char>& buffer,
              const std::string& password = std::string());
 
@@ -131,12 +138,10 @@ public:
     void close();
 
 private:
-
     //! \brief Relese memory
     void release();
 
 private:
-
     std::istream& m_ibuffer;
     std::vector<unsigned char>& m_vecbuffer;
     std::string m_zipname;
@@ -155,7 +160,6 @@ private:
 class ZipEntry
 {
 private:
-
     typedef struct
     {
         unsigned int tm_sec;
@@ -167,7 +171,6 @@ private:
     } tm_s;
 
 public:
-
     ZipEntry(const std::string& name,
              unsigned long long int compressed_size,
              unsigned long long int uncompressed_size,
@@ -178,8 +181,7 @@ public:
              unsigned int minute,
              unsigned int second,
              unsigned long dosdate)
-        : name(name), compressedSize(compressed_size),
-          uncompressedSize(uncompressed_size), dosdate(dosdate)
+        : name(name), compressedSize(compressed_size), uncompressedSize(uncompressed_size), dosdate(dosdate)
     {
         // timestamp YYYY-MM-DD HH:MM:SS
         std::stringstream str;

--- a/zipper/zipper.h
+++ b/zipper/zipper.h
@@ -15,12 +15,10 @@ namespace zipper {
 class Zipper
 {
 public:
-
     // -------------------------------------------------------------------------
     //! \brief Compression options.
     // -------------------------------------------------------------------------
-    enum zipFlags
-    {
+    enum zipFlags {
         //! \brief Minizip options/params: -o  Overwrite existing file.zip
         Overwrite = 0x01,
         //! \brief Minizip options/params: -a  Append to existing file.zip
@@ -45,6 +43,7 @@ public:
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
     Zipper(const std::string& zipname, const std::string& password = std::string());
+    Zipper(std::error_code& ec, const std::string& zipname, const std::string& password = std::string());
 
     // -------------------------------------------------------------------------
     //! \brief In-memory zip compression (storage inside std::iostream).
@@ -54,6 +53,7 @@ public:
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
     Zipper(std::iostream& buffer, const std::string& password = std::string());
+    Zipper(std::error_code& ec, std::iostream& buffer, const std::string& password = std::string());
 
     // -------------------------------------------------------------------------
     //! \brief In-memory zip compression (storage inside std::vector).
@@ -62,8 +62,8 @@ public:
     //! \param[in] password: optional password (set empty for not using password).
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
-    Zipper(std::vector<unsigned char>& buffer,
-           const std::string& password = std::string());
+    Zipper(std::vector<unsigned char>& buffer, const std::string& password = std::string());
+    Zipper(std::error_code& ec, std::vector<unsigned char>& buffer, const std::string& password = std::string());
 
     // -------------------------------------------------------------------------
     //! \brief Call close().
@@ -82,6 +82,8 @@ public:
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
     bool add(std::istream& source, const std::tm& timestamp,
+             const std::string& nameInZip, std::error_code& ec, zipFlags flags = Better);
+    bool add(std::istream& source, const std::tm& timestamp,
              const std::string& nameInZip, zipFlags flags = Better);
 
     // -------------------------------------------------------------------------
@@ -94,6 +96,8 @@ public:
     //! \return true on success, else return false.
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
+    bool add(std::istream& source, const std::string& nameInZip, std::error_code& ec,
+             zipFlags flags = Better);
     bool add(std::istream& source, const std::string& nameInZip,
              zipFlags flags = Better);
 
@@ -105,6 +109,7 @@ public:
     //! \return true on success, else return false.
     //! \throw std::runtime_error if something odd happened.
     // -------------------------------------------------------------------------
+    bool add(const std::string& fileOrFolderPath, std::error_code& ec, zipFlags flags = Better);
     bool add(const std::string& fileOrFolderPath, zipFlags flags = Better);
 
     // -------------------------------------------------------------------------
@@ -122,13 +127,12 @@ public:
     //! \note this method is not called by the constructor.
     // -------------------------------------------------------------------------
     void open();
+    void open(std::error_code& ec);
 
 private:
-
     void release();
 
 private:
-
     std::iostream& m_obuffer;
     std::vector<unsigned char>& m_vecbuffer;
     std::string m_zipname;


### PR DESCRIPTION
Here is an example that should help with #88 
I do not remove exeption to keep compatibility with the old API, similar to what can be found in `std::filesystem`