### PR TITLE
Fix CMake find_package not finding zipper when installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,10 +405,10 @@ install(FILES
         DESTINATION include/zipper)
 
 install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-        DESTINATION lib${LIB_SUFFIX}/cmake)
+        DESTINATION lib${LIB_SUFFIX}/cmake/zipper)
 
 install(EXPORT ${PROJECT_NAME}
-        DESTINATION lib${LIB_SUFFIX}/cmake
+        DESTINATION lib${LIB_SUFFIX}/cmake/zipper
         FILE ${PROJECT_NAME}Targets.cmake)
 
 message(STATUS "


### PR DESCRIPTION
With Zipper built and installed using CMake 3.19.3 on Windows 10, my project failed to find Zipper with find_package. After some investigation, I found that Zipper's config file is not properly being installed into a directory CMake will expect to find it.

`zipperConfig.cmake` is currently installed to `zipper/lib/cmake/zipperConfig.cmake`. However, on their site, CMake explains the [CMake find_package search procedure](https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure) find_package uses in config mode. If you look at the list, you'll find that CMake is expecting to find one of the following patterns:

```
<prefix-path>/zipperConfig.cmake
<prefix-path>/cmake/zipperConfig.cmake
<prefix-path>/zipper*/zipperConfig.cmake
<prefix-path>/zipper*/cmake/zipperConfig.cmake
<prefix-path>/lib/cmake/zipper*/zipperConfig.cmake
<prefix-path>/lib/zipper*/zipperConfig.cmake
<prefix-path>/lib/zipper*/cmake/zipperConfig.cmake
<prefix-path>/zipper*/lib/cmake/zipper*/zipperConfig.cmake
<prefix-path>/zipper*/lib/zipper/zipperConfig.cmake
<prefix-path>/zipper*/lib/zipper/cmake/zipperConfig.cmake
```

None of these match the actual current install directory, so find_package will not be able to correctly load the package and its targets.

In my experience, the most common pattern used is `<prefix-path>/zipper/lib/cmake/zipper/zipperConfig.cmake`, so I changed the target install command to install the targets and config files to this directory.