### PR TITLE
Fix exit after directory unzip issue

### DIFF
--- a/zipper/unzipper.cpp
+++ b/zipper/unzipper.cpp
@@ -124,17 +124,25 @@ public:
         if (!entryinfo.valid())
             return false;
 
-        err = extractToFile(fileName, entryinfo);
-        if (UNZ_OK == err)
+        if (!entryinfo.uncompressedSize)
         {
-            err = unzCloseCurrentFile(m_zf);
-            if (UNZ_OK != err)
+            if (!makedir(fileName))
+                err = UNZ_ERRNO;
+        }
+        else
+        {
+            err = extractToFile(fileName, entryinfo);
+            if (UNZ_OK == err)
             {
-                std::stringstream str;
-                str << "Error " << err << " openinginternal file '"
-                    << entryinfo.name << "' in zip";
+                err = unzCloseCurrentFile(m_zf);
+                if (UNZ_OK != err)
+                {
+                    std::stringstream str;
+                    str << "Error " << err << " openinginternal file '"
+                        << entryinfo.name << "' in zip";
 
-                throw EXCEPTION_CLASS(str.str().c_str());
+                    throw EXCEPTION_CLASS(str.str().c_str());
+                }
             }
         }
 


### PR DESCRIPTION
The following code fails to extract the zip file:
```
    Unzipper unzipper(downloadedFileName);
    unzipper.extract(extractDir);
    unzipper.close();
```
When a directory w/o filename is the entry then there is no possibility to create a file from it with `ofstream,` `extractToFile` returns error all the time and further file processing just stops.
