### PR TITLE
Fix directory creation when end with separator

### DIFF
--- a/zipper/CDirEntry.cpp
+++ b/zipper/CDirEntry.cpp
@@ -151,9 +151,9 @@ std::string CDirEntry::dirName(const std::string& path)
     if (end == path.length() - 1)
     {
 #if defined(USE_WINDOWS) // WIN32 also understands '/' as the separator.
-        end = path.find_last_of(Separator + "/", end);
+        end = path.find_last_of(Separator + "/", end - 1);
 #else
-        end = path.find_last_of(Separator, end);
+        end = path.find_last_of(Separator, end - 1);
 #endif
     }
 


### PR DESCRIPTION
According to pos parameter description the position is inclusive:
```
Position of the last character in the string to be considered in the search.
Any value greater than, or equal to, the string length (including string::npos) means that the entire string is searched.
Note: The first character is denoted by a value of 0 (not 1).
```
Please see: http://www.cplusplus.com/reference/string/string/find_last_of/.

Such case the directory is created with the actual code but the return value is false:
`makedir("c:/Data/");`
