### PR TITLE
Fix build error on windows

### DIFF
--- a/zipper/defs.h
+++ b/zipper/defs.h
@@ -42,6 +42,7 @@ typedef struct stat STAT;
 
 #if defined(USE_WINDOWS)
 #    define USEWIN32IOAPI
+#    include "ioapi.h"
 #    include "iowin32.h"
 #endif
 }


### PR DESCRIPTION
ioapi.h needs to be included before iowin32.h as iowin32.h (a minizip header pulled in as a submodule) references definitions in ioapi.h that are not defined in iowin32.h. Ideally this would be fixed in minizip's iowin32.h but simply including before #include-ing also fixes the issue at the zipper project level.