### PR TITLE
update ld cache after install

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Following the previous section `Compiling`, still from the `build` folder, type:
 
 ```shell
 sudo make install
+sudo ldconfig
 ```
 
 You will see a message like:


### PR DESCRIPTION
after following your instructions i was getting this error :
./a.out: error while loading shared libraries: libZipper.so.1: cannot open shared object file: No such file or directory

although the file was there and pkg-config was giving the right output

turned out i had to update the linker cache
